### PR TITLE
Updates socket.io to v1.3.5. "io.set" and "io.get" are deprecated as …

### DIFF
--- a/lib/statsd-socket.io.js
+++ b/lib/statsd-socket.io.js
@@ -1,6 +1,8 @@
 var util = require('util');
 var vm = require('vm');
 var io = require('socket.io');
+var levelup = require('levelup');
+var memdown = require('memdown');
 
 var debug;
 
@@ -13,7 +15,7 @@ var emit_stats = function (socket, ts, metrics) {
   });
 
   var sandbox = vm.createContext(deep_metrics);
-  socket.get('stats', function (err, stats) {
+  storage.get([ socket.id, 'stats' ], function (e, stats){
     stats.forEach(function (stat) {
       if (stat == 'all') {
         socket.emit('all', deep_metrics);
@@ -74,6 +76,8 @@ var deepen = function (o) {
   return oo;
 };
 
+var storage = levelup({ db: memdown, keyEncoding: 'json', valueEncoding: 'json' });
+
 exports.init = function (startup_time, config, events) {
   debug = config.debug;
 
@@ -85,14 +89,18 @@ exports.init = function (startup_time, config, events) {
   io = io.listen(config.socketPort);
 
   if (debug) {
-    io.set('log level', 4);
+    storage.put('log level', 4, function (){
+
+    });
   }
   else {
-    io.set('log level', 1);
+    storage.put('log level', 1, function (){
+
+    });
   }
 
   io.sockets.on('connection', function (socket) {
-    socket.set('stats', []);
+    storage.put([socket.id, 'stats'], [], function (e) {  })
 
     var emitter = function (ts, metrics) {
       emit_stats(socket, ts, metrics);
@@ -100,26 +108,25 @@ exports.init = function (startup_time, config, events) {
     events.on('flush', emitter);
 
     socket.on('subscribe', function (stat, callback) {
-      socket.get('stats', function (err, stats) {
+      storage.get([ socket.id, 'stats' ], function (e, stats){
         stats.push(stat);
-        socket.set('stats', stats);
-
-        if (callback) {
-          callback('subscribed ' + stat);
-        }
+        storage.put([ socket.id, 'stats' ], stats, function () {
+          callback && callback('subscribed ' + stat);
+        });
       });
     });
 
     socket.on('unsubscribe', function (stat, callback) {
-      socket.get('stats', function (err, stats) {
+      storage.get([ socket.id, 'stats' ], function (e, stats){
         for (var i = 0; i < stats.length; i++) {
           if (stats[i] == stat) {
             stats.splice(i, 1);
-            socket.set('stats', stats);
+             storage.put([ socket.id, 'stats' ], stats, function () {
 
-            if (callback) {
-              callback('unsubscribed ' + stat);
-            }
+              if (callback) {
+                callback('unsubscribed ' + stat);
+              }
+            });
           }
         }
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "test": "vows --spec"
   },
   "dependencies": {
-    "socket.io": "0.9.x"
+    "levelup": "^1.0.0-5",
+    "memdown": "^1.0.0",
+    "socket.io": "^1.3.5"
   },
   "devDependencies": {
     "vows": "0.7.x",


### PR DESCRIPTION
…of socket.io version 1, replaced "io.{set,get}" with alightweight in memory datastore (leveldb)"
